### PR TITLE
Filter notifications by event type to prevent false positives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .DS_Store
 CLAUDE.md
 PUBLISHING.md
+_local/

--- a/extension.js
+++ b/extension.js
@@ -3,42 +3,33 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-// Path to the notification trigger file
-const NOTIFY_FILE = '/tmp/claude-notify';
+const NOTIFY_FILE = path.join(os.tmpdir(), 'claude-notify');
 
 let fileWatcher = null;
+let isHandling = false;
 
-/**
- * Activates the extension
- */
 function activate(context) {
     console.log('Claude Code Notifier is now active');
 
-    // Register test command
     let testCommand = vscode.commands.registerCommand('claude-notifier.notify', function () {
-        vscode.window.showInformationMessage('Claude Code Notifier is working! 🎉');
+        const payload = JSON.stringify({ event: 'permission_prompt', text: 'Test: Claude needs your permission' });
+        try {
+            fs.writeFileSync(NOTIFY_FILE, payload, 'utf8');
+        } catch (err) {
+            vscode.window.showErrorMessage('Could not write test notification: ' + err.message);
+        }
     });
 
     context.subscriptions.push(testCommand);
 
-    // Start watching for the notification file
     startFileWatcher();
 
-    // Clean up on deactivation
     context.subscriptions.push({
-        dispose: () => {
-            if (fileWatcher) {
-                fileWatcher.close();
-            }
-        }
+        dispose: () => stopFileWatcher()
     });
 }
 
-/**
- * Starts watching for the notification trigger file
- */
 function startFileWatcher() {
-    // Ensure the file exists (create empty file)
     if (!fs.existsSync(NOTIFY_FILE)) {
         try {
             fs.writeFileSync(NOTIFY_FILE, '', 'utf8');
@@ -47,78 +38,91 @@ function startFileWatcher() {
         }
     }
 
-    // Watch the file for changes
     try {
-        fileWatcher = fs.watch(NOTIFY_FILE, (eventType, filename) => {
-            if (eventType === 'change') {
-                handleNotification();
-            }
+        fileWatcher = fs.watch(NOTIFY_FILE, (eventType) => {
+            if (eventType === 'change') handleNotification();
         });
         console.log(`Watching for notifications at: ${NOTIFY_FILE}`);
     } catch (err) {
         console.error('Failed to watch notification file:', err);
     }
 
-    // Also check periodically (fallback in case fs.watch misses changes)
     let lastMtime = 0;
     setInterval(() => {
         try {
             if (fs.existsSync(NOTIFY_FILE)) {
                 const stats = fs.statSync(NOTIFY_FILE);
-                if (stats.mtimeMs > lastMtime && lastMtime !== 0) {
-                    handleNotification();
-                }
+                if (stats.mtimeMs > lastMtime && lastMtime !== 0) handleNotification();
                 lastMtime = stats.mtimeMs;
             }
-        } catch (err) {
-            // Ignore errors
-        }
+        } catch (_) {}
     }, 1000);
 }
 
-/**
- * Reads the notification file and shows the message
- */
-function handleNotification() {
+function stopFileWatcher() {
+    if (fileWatcher) {
+        fileWatcher.close();
+        fileWatcher = null;
+    }
+}
+
+function parsePayload(raw) {
     try {
-        if (!fs.existsSync(NOTIFY_FILE)) {
+        const data = JSON.parse(raw);
+        return {
+            event: typeof data.event === 'string' ? data.event : 'notification',
+            text: typeof data.text === 'string' ? data.text : raw
+        };
+    } catch (_) {
+        return { event: 'notification', text: raw };
+    }
+}
+
+function getAllowedEvents() {
+    const cfg = vscode.workspace.getConfiguration('claudeCodeNotifier');
+    const list = cfg.get('allowedEvents', ['permission_prompt', 'elicitation_dialog']);
+    return new Set(list);
+}
+
+function handleNotification() {
+    if (isHandling) return;
+    isHandling = true;
+
+    try {
+        if (!fs.existsSync(NOTIFY_FILE)) { isHandling = false; return; }
+
+        const raw = fs.readFileSync(NOTIFY_FILE, 'utf8').trim();
+        if (!raw) { isHandling = false; return; }
+
+        const { event, text } = parsePayload(raw);
+
+        if (!getAllowedEvents().has(event)) {
+            console.log(`Skipped notification for event type: ${event}`);
+            isHandling = false;
             return;
         }
 
-        // Read the notification message
-        const message = fs.readFileSync(NOTIFY_FILE, 'utf8').trim();
-
-        if (!message) {
-            return;
-        }
-
-        // Show the notification in VS Code
-        vscode.window.showWarningMessage(`🔔 Claude Code: ${message}`, 'OK').then(() => {
-            // Clear the file after notification is acknowledged
-            try {
-                fs.writeFileSync(NOTIFY_FILE, '', 'utf8');
-            } catch (err) {
-                console.error('Failed to clear notification file:', err);
+        vscode.window.showWarningMessage(`🔔 Claude Code: ${text}`, 'OK').then(selection => {
+            if (selection === 'OK') {
+                try {
+                    fs.writeFileSync(NOTIFY_FILE, '', 'utf8');
+                } catch (err) {
+                    console.error('Failed to clear notification file:', err);
+                }
             }
+            isHandling = false;
         });
 
-        console.log('Notification shown:', message);
+        console.log(`Notification shown [${event}]:`, text);
 
     } catch (err) {
         console.error('Failed to handle notification:', err);
+        isHandling = false;
     }
 }
 
-/**
- * Deactivates the extension
- */
 function deactivate() {
-    if (fileWatcher) {
-        fileWatcher.close();
-    }
+    stopFileWatcher();
 }
 
-module.exports = {
-    activate,
-    deactivate
-};
+module.exports = { activate, deactivate };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-notifier",
   "displayName": "Claude Code Notifier",
   "description": "Get VS Code notifications when Claude Code needs your attention - never miss a question or permission request",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "erdemgiray",
   "author": {
     "name": "Erdem Giray"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,17 @@
         "command": "claude-notifier.notify",
         "title": "Claude Code: Send Test Notification"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Claude Code Notifier",
+      "properties": {
+        "claudeCodeNotifier.allowedEvents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["permission_prompt", "elicitation_dialog"],
+          "description": "Event types that trigger a VS Code notification. Hooks that fire during autonomous tool use (e.g. pre_tool_use) can be excluded here to prevent false positives."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #2

## What changed

Hooks now write a small JSON payload to the trigger file instead of plain text:

```bash
echo '{"event":"permission_prompt","text":"Claude needs your permission"}' > /tmp/claude-notify
```

The extension reads the `event` field and only shows a notification if that type is in the `allowedEvents` list. By default only `permission_prompt` and `elicitation_dialog` are allowed, so hooks that fire during autonomous tool execution (e.g. `pre_tool_use`) are silently skipped.

Users can customize which event types trigger notifications via VS Code settings:

```json
"claudeCodeNotifier.allowedEvents": ["permission_prompt", "elicitation_dialog"]
```

## Backward compatibility

Plain-text payloads from older hook configurations continue to work — they are treated as event type `notification` and shown unconditionally.