### PR TITLE
Auto-install hook script and settings.json on activate

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,14 +3,22 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { parsePayload, isAllowedEvent } = require('./lib/payload');
+const { install: installHooks } = require('./lib/hook-installer');
 
 const NOTIFY_FILE = path.join(os.tmpdir(), 'claude-notify');
+const NOTIFY_SCRIPT_DEST = path.join(os.homedir(), '.claude', 'notify.py');
 
 let fileWatcher = null;
 let isHandling = false;
 
 function activate(context) {
     console.log('Claude Code Notifier is now active');
+
+    installHooks({
+        settingsPath: path.join(os.homedir(), '.claude', 'settings.json'),
+        notifyScriptSrc: path.join(context.extensionPath, 'hooks', 'notify.py'),
+        notifyScriptDest: NOTIFY_SCRIPT_DEST,
+    });
 
     let testCommand = vscode.commands.registerCommand('claude-notifier.notify', function () {
         const payload = JSON.stringify({ event: 'permission_prompt', text: 'Test: Claude needs your permission' });

--- a/lib/hook-installer.js
+++ b/lib/hook-installer.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+
+const SENTINEL = '# claude-code-notifier';
+
+function isManaged(hookEntry) {
+    return Array.isArray(hookEntry.hooks) &&
+        hookEntry.hooks.some(h => typeof h.command === 'string' && h.command.includes(SENTINEL));
+}
+
+function buildSettings(settings, notifyScriptPath) {
+    const result = JSON.parse(JSON.stringify(settings));
+    if (!result.hooks) result.hooks = {};
+    if (!result.hooks.Notification) result.hooks.Notification = [];
+
+    if (result.hooks.Notification.some(isManaged)) {
+        return { settings: result, installed: false };
+    }
+
+    result.hooks.Notification.push({
+        matcher: 'permission_prompt|elicitation_dialog',
+        hooks: [{ type: 'command', command: `python3 "${notifyScriptPath}" ${SENTINEL}` }]
+    });
+
+    return { settings: result, installed: true };
+}
+
+function removeManaged(settings) {
+    const result = JSON.parse(JSON.stringify(settings));
+    if (!result.hooks) return { settings: result, removed: 0 };
+
+    let removed = 0;
+    for (const section of Object.keys(result.hooks)) {
+        const before = result.hooks[section].length;
+        result.hooks[section] = result.hooks[section].filter(e => !isManaged(e));
+        removed += before - result.hooks[section].length;
+        if (result.hooks[section].length === 0) delete result.hooks[section];
+    }
+    if (Object.keys(result.hooks).length === 0) delete result.hooks;
+
+    return { settings: result, removed };
+}
+
+function readSettings(filePath) {
+    try {
+        const raw = fs.readFileSync(filePath, 'utf8').trim();
+        if (!raw) return {};
+        return JSON.parse(raw);
+    } catch (_) {
+        return {};
+    }
+}
+
+function writeSettings(filePath, settings) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+}
+
+function install({ settingsPath, notifyScriptSrc, notifyScriptDest }) {
+    const settings = readSettings(settingsPath);
+    const { settings: newSettings, installed } = buildSettings(settings, notifyScriptDest);
+    writeSettings(settingsPath, newSettings);
+
+    let scriptCopied = false;
+    if (!fs.existsSync(notifyScriptDest)) {
+        fs.mkdirSync(path.dirname(notifyScriptDest), { recursive: true });
+        fs.copyFileSync(notifyScriptSrc, notifyScriptDest);
+        scriptCopied = true;
+    }
+
+    return { installed, scriptCopied };
+}
+
+function uninstall({ settingsPath }) {
+    const settings = readSettings(settingsPath);
+    const { settings: newSettings, removed } = removeManaged(settings);
+    if (removed > 0) writeSettings(settingsPath, newSettings);
+    return { removed };
+}
+
+module.exports = { install, uninstall, isManaged, buildSettings, removeManaged, SENTINEL };

--- a/test/hook-installer.test.js
+++ b/test/hook-installer.test.js
@@ -1,0 +1,211 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+    isManaged, buildSettings, removeManaged, install, uninstall, SENTINEL
+} = require('../lib/hook-installer');
+
+// ── pure function tests (no file I/O) ───────────────────────────────────────
+
+describe('isManaged', () => {
+    test('returns true for entries with our sentinel', () => {
+        const entry = { hooks: [{ type: 'command', command: `python3 /some/path ${SENTINEL}` }] };
+        expect(isManaged(entry)).toBe(true);
+    });
+
+    test('returns false for entries without our sentinel', () => {
+        const entry = { hooks: [{ type: 'command', command: 'echo hello' }] };
+        expect(isManaged(entry)).toBe(false);
+    });
+
+    test('returns false for entries with no hooks array', () => {
+        expect(isManaged({})).toBe(false);
+        expect(isManaged({ hooks: [] })).toBe(false);
+    });
+});
+
+describe('buildSettings', () => {
+    const scriptPath = '/home/user/.claude/notify.py';
+
+    test('adds Notification hook to empty settings', () => {
+        const { settings, installed } = buildSettings({}, scriptPath);
+        expect(installed).toBe(true);
+        expect(settings.hooks.Notification).toHaveLength(1);
+        expect(settings.hooks.Notification[0].matcher).toBe('permission_prompt|elicitation_dialog');
+        expect(settings.hooks.Notification[0].hooks[0].command).toContain(scriptPath);
+        expect(settings.hooks.Notification[0].hooks[0].command).toContain(SENTINEL);
+    });
+
+    test('adds hook alongside existing unrelated hooks', () => {
+        const existing = {
+            hooks: {
+                PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'lint.sh' }] }]
+            }
+        };
+        const { settings, installed } = buildSettings(existing, scriptPath);
+        expect(installed).toBe(true);
+        expect(settings.hooks.PreToolUse).toHaveLength(1);
+        expect(settings.hooks.Notification).toHaveLength(1);
+    });
+
+    test('adds hook alongside existing unrelated Notification entries', () => {
+        const existing = {
+            hooks: {
+                Notification: [{ matcher: 'idle_prompt', hooks: [{ type: 'command', command: 'other.sh' }] }]
+            }
+        };
+        const { settings, installed } = buildSettings(existing, scriptPath);
+        expect(installed).toBe(true);
+        expect(settings.hooks.Notification).toHaveLength(2);
+        expect(settings.hooks.Notification[0].hooks[0].command).toBe('other.sh');
+    });
+
+    test('is idempotent — skips if our hook is already present', () => {
+        const { settings: first } = buildSettings({}, scriptPath);
+        const { settings: second, installed } = buildSettings(first, scriptPath);
+        expect(installed).toBe(false);
+        expect(second.hooks.Notification).toHaveLength(1);
+    });
+
+    test('does not mutate the original settings object', () => {
+        const original = {};
+        buildSettings(original, scriptPath);
+        expect(original.hooks).toBeUndefined();
+    });
+});
+
+describe('removeManaged', () => {
+    const scriptPath = '/home/user/.claude/notify.py';
+
+    test('removes our hook entry', () => {
+        const { settings: withHook } = buildSettings({}, scriptPath);
+        const { settings, removed } = removeManaged(withHook);
+        expect(removed).toBe(1);
+        expect(settings.hooks).toBeUndefined();
+    });
+
+    test('leaves unrelated hooks untouched', () => {
+        const input = {
+            hooks: {
+                PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'lint.sh' }] }]
+            }
+        };
+        const { settings, removed } = removeManaged(input);
+        expect(removed).toBe(0);
+        expect(settings.hooks.PreToolUse).toHaveLength(1);
+    });
+
+    test('removes only our entry when mixed with unrelated ones', () => {
+        const existing = {
+            hooks: {
+                Notification: [{ matcher: 'idle_prompt', hooks: [{ type: 'command', command: 'other.sh' }] }]
+            }
+        };
+        const { settings: withBoth } = buildSettings(existing, scriptPath);
+        const { settings, removed } = removeManaged(withBoth);
+        expect(removed).toBe(1);
+        expect(settings.hooks.Notification).toHaveLength(1);
+        expect(settings.hooks.Notification[0].hooks[0].command).toBe('other.sh');
+    });
+
+    test('handles settings with no hooks key', () => {
+        const { settings, removed } = removeManaged({});
+        expect(removed).toBe(0);
+        expect(settings.hooks).toBeUndefined();
+    });
+
+    test('does not mutate the original settings object', () => {
+        const { settings: withHook } = buildSettings({}, scriptPath);
+        const original = JSON.parse(JSON.stringify(withHook));
+        removeManaged(withHook);
+        expect(withHook).toEqual(original);
+    });
+});
+
+// ── file I/O tests (use temp directories) ───────────────────────────────────
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'hook-installer-test-'));
+}
+
+describe('install', () => {
+    let tmpDir, settingsPath, scriptSrc, scriptDest;
+
+    beforeEach(() => {
+        tmpDir = makeTempDir();
+        settingsPath = path.join(tmpDir, 'settings.json');
+        scriptSrc = path.join(tmpDir, 'notify.py');
+        scriptDest = path.join(tmpDir, 'dest', 'notify.py');
+        fs.writeFileSync(scriptSrc, '# notify script');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('creates settings.json when it does not exist', () => {
+        install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest });
+        expect(fs.existsSync(settingsPath)).toBe(true);
+        const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        expect(written.hooks.Notification).toHaveLength(1);
+    });
+
+    test('copies notify.py to destination', () => {
+        install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest });
+        expect(fs.existsSync(scriptDest)).toBe(true);
+        expect(fs.readFileSync(scriptDest, 'utf8')).toBe('# notify script');
+    });
+
+    test('handles malformed settings.json gracefully', () => {
+        fs.writeFileSync(settingsPath, 'this is not json }{');
+        expect(() => install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest })).not.toThrow();
+        const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        expect(written.hooks.Notification).toHaveLength(1);
+    });
+
+    test('handles empty settings.json gracefully', () => {
+        fs.writeFileSync(settingsPath, '');
+        expect(() => install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest })).not.toThrow();
+    });
+
+    test('does not overwrite existing notify.py', () => {
+        fs.mkdirSync(path.dirname(scriptDest), { recursive: true });
+        fs.writeFileSync(scriptDest, '# existing script');
+        const { scriptCopied } = install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest });
+        expect(scriptCopied).toBe(false);
+        expect(fs.readFileSync(scriptDest, 'utf8')).toBe('# existing script');
+    });
+
+    test('is idempotent — running twice does not duplicate hooks', () => {
+        install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest });
+        install({ settingsPath, notifyScriptSrc: scriptSrc, notifyScriptDest: scriptDest });
+        const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        expect(written.hooks.Notification).toHaveLength(1);
+    });
+});
+
+describe('uninstall', () => {
+    let tmpDir, settingsPath;
+
+    beforeEach(() => {
+        tmpDir = makeTempDir();
+        settingsPath = path.join(tmpDir, 'settings.json');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('removes our hook and cleans up empty sections', () => {
+        const { settings } = buildSettings({}, '/some/notify.py');
+        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+        const { removed } = uninstall({ settingsPath });
+        expect(removed).toBe(1);
+        const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        expect(written.hooks).toBeUndefined();
+    });
+
+    test('handles missing settings.json gracefully', () => {
+        expect(() => uninstall({ settingsPath })).not.toThrow();
+    });
+});


### PR DESCRIPTION
Closes #9

On first `activate`, the extension:
1. Copies `hooks/notify.py` → `~/.claude/notify.py`
2. Adds our `Notification` hook entries to `~/.claude/settings.json`

Subsequent activations are idempotent. Unrelated hooks in `settings.json` are never touched.

## Architecture

All logic lives in `lib/hook-installer.js` with no VS Code imports — fully testable with Jest. `extension.js` calls a single `installHooks()` function.

Pure functions (`buildSettings`, `removeManaged`) are tested independently of file I/O, making edge cases easy to cover:

| Test | Coverage |
|---|---|
| Empty settings.json | ✅ |
| Existing unrelated hooks | ✅ |
| Existing unrelated Notification entries | ✅ |
| Idempotent (no duplicate hooks) | ✅ |
| Malformed settings.json | ✅ |
| Missing settings.json | ✅ |
| Does not overwrite existing notify.py | ✅ |
| Uninstall cleans up our entries only | ✅ |

21 new Jest tests + all 40 existing tests still pass.